### PR TITLE
fix: Implement a fix to allow relative urls to work from the main readme for sites that are hosted on ReadtheDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__
 *.DS_Store
 *.md.html
 .tox
+.idea/
+.venv*/
+mycommand.md.markdown

--- a/src/mkdocs_ezglossary_plugin/plugin.py
+++ b/src/mkdocs_ezglossary_plugin/plugin.py
@@ -115,7 +115,7 @@ class GlossaryPlugin(BasePlugin[GlossaryConfig]):
     def on_post_page(self, output, page, config):
         _dir = os.path.dirname(page.url)
         levels = len(_dir.split("/"))
-        if page.abs_url == "/":
+        if page.canonical_url.replace(config.site_url or "", "").lstrip("/").count("/") < 1:
             root = "./" * levels
         else:
             root = "../" * levels

--- a/src/mkdocs_ezglossary_plugin/plugin.py
+++ b/src/mkdocs_ezglossary_plugin/plugin.py
@@ -115,7 +115,10 @@ class GlossaryPlugin(BasePlugin[GlossaryConfig]):
     def on_post_page(self, output, page, config):
         _dir = os.path.dirname(page.url)
         levels = len(_dir.split("/"))
-        root = "../" * levels
+        if page.abs_url == "/":
+            root = "./" * levels
+        else:
+            root = "../" * levels
         output = self._replace_glossary_links(output, page, root)
         output = self._replace_inline_refs(output, page, root)
         output = self._print_glossary(output, root)

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -24,7 +24,7 @@ class Page:
         return self.file
 
     @property
-    def abs_url(self):
+    def canonical_url(self):
         return f"/{self.file.rsplit('.', maxsplit=1)[0]}/"
 
     @staticmethod

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -23,6 +23,10 @@ class Page:
     def url(self):
         return self.file
 
+    @property
+    def abs_url(self):
+        return f"/{self.file.rsplit('.', maxsplit=1)[0]}/"
+
     @staticmethod
     def fromdict(data: dict):
         return Page(data['title'], data['file'], data['html'])
@@ -52,7 +56,7 @@ def render(pages, config):
         if page.ctype == "html":
             results[page.url] = plugin.on_post_page(results[page.url], page, config)
     for page in pages:
-        fp = open(page.url + "." + page.ctype, "w")
+        fp = open(page.url + "." + page.ctype, "w", encoding="utf-8")
         fp.write(results[page.url])
         fp.close()
         log.debug(f"--- >>> {page.url}")


### PR DESCRIPTION
This adds a check to change the relative link for the main page of the site so that the relative links work correctly for sites that are hosted on ReadtheDocs.

fixes: #16 